### PR TITLE
Updating Dependencies

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,6 @@
+# Browsers to support when transpiling.
+
+last 1 version
+> 1%
+maintained node versions
+not dead

--- a/README.md
+++ b/README.md
@@ -4,31 +4,32 @@ Ready-to-fork setup of Babel, Gulp and Jekyll for GitHub Pages. [Showcase / Blog
 
 ## Usage
 1. Fork the repo
-2. Run <code>npm install</code> in the root directory to install Gulp and Babel locally.
-3. Run <code>gulp jekyll</code> to build the site with Babel and serve it with Jekyll afterwards. Visit <a href="http://localhost:4000" target="_blank">http://localhost:4000</a> to see the blog.</li>
-</ol>
+2. Run `npm install` in the root directory to install Gulp and Babel locally.
+3. Run `npx gulp jekyll` to build the site with Babel and serve it with Jekyll afterwards. Visit <a href="http://localhost:4000" target="_blank">http://localhost:4000</a> to see the blog.
 
 
 ## Development
-The <code>master</code> branch should only be used for deploying (see considerations below). For development, switch to the <code>dev</code> branch. After implementing your changes, test them by running <code>gulp jekyll</code> and visiting <a href="http://localhost:4000" target="_blank">http://localhost:4000</a>
+The `master` branch should only be used for deploying (see considerations below). For development, switch to the `dev` branch. After implementing your changes, test them by running `npx gulp jekyll` and visiting <a href="http://localhost:4000" target="_blank">http://localhost:4000</a>
 
-If you are happy, checkout the <code>master</code> branch, merge the <code>dev</code> branch, run <code>gulp</code> to build the site into the project's root directory and push / deploy the new build to the <code>master</code> branch on GitHub.
+If you are happy, checkout the `master` branch, merge the `dev` branch, run `npx gulp` to build the site into the project's root directory and push / deploy the new build to the `master` branch on GitHub.
 
-Note: You can skip Babel during development by changing <code>source: _dist</code> to <code>source: src</code> and running <code>jekyll serve</code> in the root directory.
+Note: You can skip Babel during development by changing `source: _dist` to `source: src` and running `jekyll serve` in the root directory.
 
 ## Considerations
-* Running Babel for transpiling the ES6 files into ES5 before each deployment of the site is not practical, so a build tool like Gulp that runs Babel automatically is a must.
+* Running Babel for transpiling the files for browsers before each deployment of the site is not practical, so a build tool like Gulp that runs Babel automatically is a must.
 * There is a <a href="https://github.com/babel/jekyll-babel" target="_blank">jekyll-babel Jekyll plugin</a> but you have to start each .js file with exactly
-        <pre><code>---<br>---</code></pre>
-        WebStorm does not like that and formats it wrongly every time. If you try to escape that block with <code>// @formatter:off</code>, the Jekyll plugin won't work anymore. Also, it is a bit dirty to mess with the .js files. If I want to directly run them during development, they will error. So, Babel has to be called by Gulp.
-* Babel will generate the transpiled .js files somewhere. I don't want these files to mingle with the actual source .js files - that would cause confusion. So, using a <code>src</code> and a <code>_dist</code> directory (ignored by git) would be clean. Jekyll can then generate the static site in <code>_site</code> by using the files in <code>_dist</code>.
-* You have to commit all files that Jekyll needs to the <code>master</code> branch on GitHub. So <code>_dist</code> must not be ignored by git. At the same time it is generated code so it should be ignored. A solution is to ignore <code>_dist</code> on the <code>dev</code> branch. Then, merge the <code>dev</code> branch to the <code>master</code> branch, run Gulp and push the newly <code>_dist</code> to the GitHub <code>master</code> branch.
-* For running Jekyll on the <code>_dist</code> directory, you would have to specify <code>source: _dist</code> in Jekyll's <code>_config.yml</code>. However, GitHub overrides the <code>source</code> setting, which you cannot change (<a href="https://help.github.com/articles/configuring-jekyll/#configuration-settings-you-cannot-change" target="_blank">GitHub docs</a>). So Jekyll's source directory <strong>has to be the repo's top level directory</strong> (for username.github.io pages). You also <strong>must</strong> commit the page to the <code>master</code> branch. The solution is to keep the <code>source: _dist</code> setting for the <code>dev</code> branch, but let gulp build the site into the root directory on the <code>master</code> branch (<a href="https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/" target="_blank">docs</a>).
+  ```
+  ------
+  ```
+  WebStorm does not like that and formats it wrongly every time. If you try to escape that block with `// @formatter:off`, the Jekyll plugin won't work anymore. Also, it is a bit dirty to mess with the .js files. If I want to directly run them during development, they will error. So, Babel has to be called by Gulp.
+* Babel will generate the transpiled .js files somewhere. I don't want these files to mingle with the actual source .js files - that would cause confusion. So, using a `src` and a `_dist` directory (ignored by git) would be clean. Jekyll can then generate the static site in `_site` by using the files in `_dist`.
+* You have to commit all files that Jekyll needs to the `master` branch on GitHub. So `_dist` must not be ignored by git. At the same time it is generated code so it should be ignored. A solution is to ignore `_dist` on the `dev` branch. Then, merge the `dev` branch to the `master` branch, run Gulp and push the newly `_dist` to the GitHub `master` branch.
+* For running Jekyll on the `_dist` directory, you would have to specify `source: _dist` in Jekyll's `_config.yml`. However, GitHub overrides the `source` setting, which you cannot change (<a href="https://help.github.com/articles/configuring-jekyll/#configuration-settings-you-cannot-change" target="_blank">GitHub docs</a>). So Jekyll's source directory **has to be the repo's top level directory** (for username.github.io pages). You also **must** commit the page to the `master` branch. The solution is to keep the `source: _dist` setting for the `dev` branch, but let gulp build the site into the root directory on the `master` branch (<a href="https://help.github.com/articles/configuring-a-publishing-source-for-github-pages/" target="_blank">docs</a>).
 
 
 ## Drawbacks
 
-* On <code>master</code>, Gulp cannot clean the build directory before building because it is the project's root directory.
-* You have to go to <code>master</code>, build and push for every deployment of the site. <a href="https://github.com/shinnn/gulp-gh-pages">This gulp plugin</a> might help with that.
-* On <code>master</code>, I had to change <code>_config.yml</code> and <code>gulpfile.js</code> to make Gulp build into the root directory. Thus, changes to these files in <code>dev</code> will have to be merged manually with master.
+* On `master`, Gulp cannot clean the build directory before building because it is the project's root directory.
+* You have to go to `master`, build and push for every deployment of the site. [This gulp plugin](https://github.com/shinnn/gulp-gh-pages) might help with that.
+* On `master`, I had to change `_config.yml` and `gulpfile.js` to make Gulp build into the root directory. Thus, changes to these files in `dev` will have to be merged manually with master.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Note: You can skip Babel during development by changing `source: _dist` to `sour
 * Running Babel for transpiling the files for browsers before each deployment of the site is not practical, so a build tool like Gulp that runs Babel automatically is a must.
 * There is a <a href="https://github.com/babel/jekyll-babel" target="_blank">jekyll-babel Jekyll plugin</a> but you have to start each .js file with exactly
   ```
-  ------
+  ---
+  ---
   ```
   WebStorm does not like that and formats it wrongly every time. If you try to escape that block with `// @formatter:off`, the Jekyll plugin won't work anymore. Also, it is a bit dirty to mess with the .js files. If I want to directly run them during development, they will error. So, Babel has to be called by Gulp.
 * Babel will generate the transpiled .js files somewhere. I don't want these files to mingle with the actual source .js files - that would cause confusion. So, using a `src` and a `_dist` directory (ignored by git) would be clean. Jekyll can then generate the static site in `_site` by using the files in `_dist`.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,28 +13,29 @@ const distDir = './';
 
 // Copy all files to the dist directory. On the master-branch, we cannot clean the dist directory
 // first if it is the root directory.
-gulp.task('_copy', function () {
+function _copy() {
     return gulp.src(['src/**/*']).pipe(gulp.dest(distDir));
-});
+};
 
 // Transpile the javascript files to ES5 in the dist directory (in-place)
-gulp.task('_javascripts', ['_copy'], function () {
+// Transpile the javascript files in the dist directory (in-place)
+function _javascripts() {
     return gulp.src('js/**/*.js', {base: distDir, cwd: distDir})
         .pipe(babel({
             presets: ['es2015']
         }))
         .pipe(gulp.dest(distDir));
-});
+};
 
 // Default task producing a jekyll-ready site in the dist folder
-gulp.task('default', ['_javascripts']);
+gulp.task('default', gulp.series(_copy, _javascripts));
 
 // Run Jekyll
-gulp.task('jekyll', ['default'], function (gulpCallBack) {
+gulp.task('jekyll', gulp.series('default', function (gulpCallBack) {
     let spawn = require('child_process').spawn;
     let jekyll = spawn('jekyll', ['serve'], {stdio: 'inherit'});
 
     jekyll.on('exit', function (code) {
         gulpCallBack(code === 0 ? null : 'ERROR: Jekyll process exited with code: ' + code);
     });
-});
+}));

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,12 +17,11 @@ function _copy() {
     return gulp.src(['src/**/*']).pipe(gulp.dest(distDir));
 };
 
-// Transpile the javascript files to ES5 in the dist directory (in-place)
 // Transpile the javascript files in the dist directory (in-place)
 function _javascripts() {
     return gulp.src('js/**/*.js', {base: distDir, cwd: distDir})
         .pipe(babel({
-            presets: ['es2015']
+            presets: ['@babel/preset-env']
         }))
         .pipe(gulp.dest(distDir));
 };

--- a/js/main.js
+++ b/js/main.js
@@ -1,9 +1,9 @@
 "use strict";
 
 [1, 2, 3].forEach(function (x) {
-    return showItWorks();
+  return showItWorks();
 });
 
 function showItWorks() {
-    document.getElementById("javascript-status").innerHTML = "JavaScript transpilation works!";
+  document.getElementById("javascript-status").innerHTML = "JavaScript transpilation works!";
 }

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "devDependencies": {
     "babel-core": "^6.25.0",
     "babel-preset-es2015": "^6.24.1",
-    "gulp": "^3.9.1",
-    "gulp-babel": "latest",
     "gulp-clean": "latest"
+    "gulp": "~4.0.0",
+    "gulp-babel": "~8.0.0",
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
   },
   "homepage": "https://github.com/batzner/github-pages-boilerplate#readme",
   "devDependencies": {
-    "babel-core": "^6.25.0",
-    "babel-preset-es2015": "^6.24.1",
-    "gulp-clean": "latest"
+    "@babel/core": "~7.0.0",
+    "@babel/preset-env": "~7.0.0",
     "gulp": "~4.0.0",
     "gulp-babel": "~8.0.0",
+    "del": "~3.0.0"
   }
 }


### PR DESCRIPTION
I have already updated my website that uses this boilerplate. Now I just want to give back for the great first step.

- [x] Lock dependencies to the latest minor version (instead of the latest). This helps to reduce the chance of an update to a dependency breaking the boilerplate (which has already occurred).
- [x] Switch to organization controlled dependencies.
- [x] Update gulp to 4.0.0.
- [x] Update babel to 4.0.0.
- [x] Replace gulp-clean (deprecated) with del.
- [x] Replace babel-preset-es2015 with @babel/preset-env and add a browserslist config (sample list).
- [x] Updated dev branch (#2).